### PR TITLE
Using assertSame to make assertion equals strict

### DIFF
--- a/tests/Unit/SafeTest.php
+++ b/tests/Unit/SafeTest.php
@@ -260,7 +260,7 @@ class SafeTest extends TestCase
     {
         TypeSafe::skipChecks(true);
 
-        self::assertEquals(
+        self::assertSame(
             1,
             safe(1, Type::STRING),
         );


### PR DESCRIPTION
# Changed log

- Using assertSame to make assertion equals strict.